### PR TITLE
Validate trip resource availability and update statuses

### DIFF
--- a/backend/routes/trip.routes.js
+++ b/backend/routes/trip.routes.js
@@ -93,17 +93,48 @@ router.post('/', async (req, res) => {
 
         const statusFilter = { status: { $in: ['Scheduled', 'In Transit'] } };
 
-        if (await Trip.findOne({ IDDriver, ...statusFilter, ...timeOverlap })) {
-            return res.status(400).json({ error: 'Driver already assigned in this period' });
+        const driverConflict = await Trip.findOne({ IDDriver, ...statusFilter, ...timeOverlap });
+        if (driverConflict) {
+            return res.status(400).json({
+                error: 'El conductor ya tiene un viaje asignado en esas fechas',
+                conflicto: {
+                    scheduledDepartureDate: driverConflict.scheduledDepartureDate,
+                    scheduledArrivalDate: driverConflict.scheduledArrivalDate
+                }
+            });
         }
-        if (await Trip.findOne({ IDTruck, ...statusFilter, ...timeOverlap })) {
-            return res.status(400).json({ error: 'Truck already assigned in this period' });
+
+        const truckConflict = await Trip.findOne({ IDTruck, ...statusFilter, ...timeOverlap });
+        if (truckConflict) {
+            return res.status(400).json({
+                error: 'El camión ya tiene un viaje asignado en esas fechas',
+                conflicto: {
+                    scheduledDepartureDate: truckConflict.scheduledDepartureDate,
+                    scheduledArrivalDate: truckConflict.scheduledArrivalDate
+                }
+            });
         }
-        if (await Trip.findOne({ IDBox, ...statusFilter, ...timeOverlap })) {
-            return res.status(400).json({ error: 'Box already assigned in this period' });
+
+        const boxConflict = await Trip.findOne({ IDBox, ...statusFilter, ...timeOverlap });
+        if (boxConflict) {
+            return res.status(400).json({
+                error: 'La caja ya tiene un viaje asignado en esas fechas',
+                conflicto: {
+                    scheduledDepartureDate: boxConflict.scheduledDepartureDate,
+                    scheduledArrivalDate: boxConflict.scheduledArrivalDate
+                }
+            });
         }
-        if (await Trip.findOne({ IDRute, ...statusFilter, ...timeOverlap })) {
-            return res.status(400).json({ error: 'Route already assigned in this period' });
+
+        const routeConflict = await Trip.findOne({ IDRute, ...statusFilter, ...timeOverlap });
+        if (routeConflict) {
+            return res.status(400).json({
+                error: 'La ruta ya está asignada en esas fechas',
+                conflicto: {
+                    scheduledDepartureDate: routeConflict.scheduledDepartureDate,
+                    scheduledArrivalDate: routeConflict.scheduledArrivalDate
+                }
+            });
         }
 
         const rute = await Rute.findById(Number(IDRute));
@@ -191,17 +222,48 @@ router.put('/:id', async (req, res) => {
                 status: { $in: ['Scheduled', 'In Transit'] }
             };
 
-            if (await Trip.findOne({ IDDriver: trip.IDDriver, ...timeOverlap })) {
-                return res.status(400).json({ error: 'Driver already assigned in this period' });
+            const driverConflict = await Trip.findOne({ IDDriver: trip.IDDriver, ...timeOverlap });
+            if (driverConflict) {
+                return res.status(400).json({
+                    error: 'El conductor ya tiene un viaje asignado en esas fechas',
+                    conflicto: {
+                        scheduledDepartureDate: driverConflict.scheduledDepartureDate,
+                        scheduledArrivalDate: driverConflict.scheduledArrivalDate
+                    }
+                });
             }
-            if (await Trip.findOne({ IDTruck: trip.IDTruck, ...timeOverlap })) {
-                return res.status(400).json({ error: 'Truck already assigned in this period' });
+
+            const truckConflict = await Trip.findOne({ IDTruck: trip.IDTruck, ...timeOverlap });
+            if (truckConflict) {
+                return res.status(400).json({
+                    error: 'El camión ya tiene un viaje asignado en esas fechas',
+                    conflicto: {
+                        scheduledDepartureDate: truckConflict.scheduledDepartureDate,
+                        scheduledArrivalDate: truckConflict.scheduledArrivalDate
+                    }
+                });
             }
-            if (await Trip.findOne({ IDBox: trip.IDBox, ...timeOverlap })) {
-                return res.status(400).json({ error: 'Box already assigned in this period' });
+
+            const boxConflict = await Trip.findOne({ IDBox: trip.IDBox, ...timeOverlap });
+            if (boxConflict) {
+                return res.status(400).json({
+                    error: 'La caja ya tiene un viaje asignado en esas fechas',
+                    conflicto: {
+                        scheduledDepartureDate: boxConflict.scheduledDepartureDate,
+                        scheduledArrivalDate: boxConflict.scheduledArrivalDate
+                    }
+                });
             }
-            if (await Trip.findOne({ IDRute: trip.IDRute, ...timeOverlap })) {
-                return res.status(400).json({ error: 'Route already assigned in this period' });
+
+            const routeConflict = await Trip.findOne({ IDRute: trip.IDRute, ...timeOverlap });
+            if (routeConflict) {
+                return res.status(400).json({
+                    error: 'La ruta ya está asignada en esas fechas',
+                    conflicto: {
+                        scheduledDepartureDate: routeConflict.scheduledDepartureDate,
+                        scheduledArrivalDate: routeConflict.scheduledArrivalDate
+                    }
+                });
             }
         }
 

--- a/backend/routes/trip.routes.js
+++ b/backend/routes/trip.routes.js
@@ -1,6 +1,9 @@
 const express = require('express');
 const Rute = require('../models/Rute');
 const Trip = require('../models/Trip');
+const User = require('../models/User');
+const Truck = require('../models/Truck');
+const Box = require('../models/Box');
 
 const router = express.Router();
 
@@ -80,6 +83,29 @@ router.post('/', async (req, res) => {
             IDCargoType
         } = req.body;
 
+        const departure = new Date(scheduledDepartureDate);
+        const arrival = new Date(scheduledArrivalDate);
+
+        const timeOverlap = {
+            scheduledDepartureDate: { $lt: arrival },
+            scheduledArrivalDate: { $gt: departure }
+        };
+
+        const statusFilter = { status: { $in: ['Scheduled', 'In Transit'] } };
+
+        if (await Trip.findOne({ IDDriver, ...statusFilter, ...timeOverlap })) {
+            return res.status(400).json({ error: 'Driver already assigned in this period' });
+        }
+        if (await Trip.findOne({ IDTruck, ...statusFilter, ...timeOverlap })) {
+            return res.status(400).json({ error: 'Truck already assigned in this period' });
+        }
+        if (await Trip.findOne({ IDBox, ...statusFilter, ...timeOverlap })) {
+            return res.status(400).json({ error: 'Box already assigned in this period' });
+        }
+        if (await Trip.findOne({ IDRute, ...statusFilter, ...timeOverlap })) {
+            return res.status(400).json({ error: 'Route already assigned in this period' });
+        }
+
         const rute = await Rute.findById(Number(IDRute));
         if (!rute) {
             return res.status(404).json({ error: 'Route not found' });
@@ -155,13 +181,127 @@ router.put('/:id', async (req, res) => {
             if (scheduledArrivalDate) {
                 trip.scheduledArrivalDate = scheduledArrivalDate;
             }
+
+            const newDeparture = new Date(trip.scheduledDepartureDate);
+            const newArrival = new Date(trip.scheduledArrivalDate);
+            const timeOverlap = {
+                _id: { $ne: trip._id },
+                scheduledDepartureDate: { $lt: newArrival },
+                scheduledArrivalDate: { $gt: newDeparture },
+                status: { $in: ['Scheduled', 'In Transit'] }
+            };
+
+            if (await Trip.findOne({ IDDriver: trip.IDDriver, ...timeOverlap })) {
+                return res.status(400).json({ error: 'Driver already assigned in this period' });
+            }
+            if (await Trip.findOne({ IDTruck: trip.IDTruck, ...timeOverlap })) {
+                return res.status(400).json({ error: 'Truck already assigned in this period' });
+            }
+            if (await Trip.findOne({ IDBox: trip.IDBox, ...timeOverlap })) {
+                return res.status(400).json({ error: 'Box already assigned in this period' });
+            }
+            if (await Trip.findOne({ IDRute: trip.IDRute, ...timeOverlap })) {
+                return res.status(400).json({ error: 'Route already assigned in this period' });
+            }
         }
 
         await trip.save();
+
+        if (trip.status === 'Canceled') {
+            await Promise.all([
+                User.findByIdAndUpdate(trip.IDDriver, { status: 'Available' }),
+                Truck.findByIdAndUpdate(trip.IDTruck, { status: 'Available' }),
+                Box.findByIdAndUpdate(trip.IDBox, { status: 'Available' })
+            ]);
+        }
+
         return res.json(trip);
     } catch (err) {
         console.error('Error updating trip:', err);
         return res.status(500).json({ error: 'Error updating trip' });
+    }
+});
+
+router.post('/:id/start', async (req, res) => {
+    try {
+        const { id } = req.params;
+        const trip = await Trip.findById(id);
+        if (!trip) {
+            return res.status(404).json({ error: 'Trip not found' });
+        }
+        if (trip.status !== 'Scheduled') {
+            return res.status(400).json({ error: 'Trip cannot be started' });
+        }
+
+        trip.status = 'In Transit';
+        trip.actualDepartureDate = new Date();
+        await trip.save();
+
+        await Promise.all([
+            User.findByIdAndUpdate(trip.IDDriver, { status: 'On Trip' }),
+            Truck.findByIdAndUpdate(trip.IDTruck, { status: 'On Trip' }),
+            Box.findByIdAndUpdate(trip.IDBox, { status: 'On Trip' })
+        ]);
+
+        return res.json(trip);
+    } catch (err) {
+        console.error('Error starting trip:', err);
+        return res.status(500).json({ error: 'Error starting trip' });
+    }
+});
+
+router.post('/:id/complete', async (req, res) => {
+    try {
+        const { id } = req.params;
+        const trip = await Trip.findById(id);
+        if (!trip) {
+            return res.status(404).json({ error: 'Trip not found' });
+        }
+        if (trip.status !== 'In Transit') {
+            return res.status(400).json({ error: 'Trip cannot be completed' });
+        }
+
+        trip.status = 'Completed';
+        trip.actualArrivalDate = new Date();
+        await trip.save();
+
+        await Promise.all([
+            User.findByIdAndUpdate(trip.IDDriver, { status: 'Available' }),
+            Truck.findByIdAndUpdate(trip.IDTruck, { status: 'Available' }),
+            Box.findByIdAndUpdate(trip.IDBox, { status: 'Available' })
+        ]);
+
+        return res.json(trip);
+    } catch (err) {
+        console.error('Error completing trip:', err);
+        return res.status(500).json({ error: 'Error completing trip' });
+    }
+});
+
+router.post('/:id/cancel', async (req, res) => {
+    try {
+        const { id } = req.params;
+        const trip = await Trip.findById(id);
+        if (!trip) {
+            return res.status(404).json({ error: 'Trip not found' });
+        }
+        if (trip.status === 'Completed' || trip.status === 'Canceled') {
+            return res.status(400).json({ error: 'Trip cannot be canceled' });
+        }
+
+        trip.status = 'Canceled';
+        await trip.save();
+
+        await Promise.all([
+            User.findByIdAndUpdate(trip.IDDriver, { status: 'Available' }),
+            Truck.findByIdAndUpdate(trip.IDTruck, { status: 'Available' }),
+            Box.findByIdAndUpdate(trip.IDBox, { status: 'Available' })
+        ]);
+
+        return res.json(trip);
+    } catch (err) {
+        console.error('Error canceling trip:', err);
+        return res.status(500).json({ error: 'Error canceling trip' });
     }
 });
 


### PR DESCRIPTION
## Summary
- prevent assigning the same driver, truck, box or route to overlapping trips
- mark driver, truck and box as On Trip when a trip starts
- return driver, truck and box to Available when trips complete or are cancelled

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_689050f2005c8330960b0fbe0899b44a